### PR TITLE
Make DNF more accurate to actual timer value

### DIFF
--- a/Modules/DnfTime.cs
+++ b/Modules/DnfTime.cs
@@ -31,7 +31,7 @@ namespace NeonLite.Modules
             long best = GameDataManager.levelStats[game.GetCurrentLevel().levelID].GetTimeBestMicroseconds();
             TextMeshPro frozenText = frozenTime.GetComponent<TextMeshPro>();
             frozenText.color = best < game.GetCurrentLevelTimerMicroseconds() ? Color.red : Color.green;
-            frozenText.text = "DNF: " + frozenText.text;
+            frozenText.text = "DNF: " + IGTimer.CreateTimerText();
         }
     }
 }

--- a/Modules/IGTimer.cs
+++ b/Modules/IGTimer.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using MelonLoader;
 using System.Text;
 using UnityEngine;
@@ -60,30 +60,62 @@ namespace NeonLite.Modules
         {
             if (!_setting_IGTimer.Value) return true;
 
-            long currentLevelTimerMilliseconds = NeonLite.Game.GetCurrentLevelTimerMicroseconds() / 1000;
-            timerBuilder.Clear();
-
-            int num = (int)(currentLevelTimerMilliseconds / 60000L);
-            int num2 = (int)(currentLevelTimerMilliseconds / 1000L) % 60;
-            int num3 = (int)(currentLevelTimerMilliseconds - (num * 60000) - (num2 * 1000));
-
-            if (num > 99)
-                timerBuilder.Append((char)((num / 100) + 48));
-
-            timerBuilder.Append((char)((num / 10) + 48));
-            timerBuilder.Append((char)((num % 10) + 48));
-            timerBuilder.Append(':');
-            timerBuilder.Append((char)((num2 / 10) + 48));
-            timerBuilder.Append((char)((num2 % 10) + 48));
-            timerBuilder.Append(':');
-            timerBuilder.Append((char)((num3 / 100) + 48));
-            num3 %= 100;
-            timerBuilder.Append((char)((num3 / 10) + 48));
-            timerBuilder.Append((char)((num3 % 10) + 48));
-
             __instance.timerText.color = _setting_IGTimer_Color.Value;
-            __instance.timerText.text = timerBuilder.ToString();
+            __instance.timerText.text = CreateTimerText();
             return false;
+        }
+
+        public static string CreateTimerText()
+        {
+            if (_setting_IGTimer.Value)
+            {
+                long currentLevelTimerMilliseconds = NeonLite.Game.GetCurrentLevelTimerMicroseconds() / 1000;
+                timerBuilder.Clear();
+
+                int num = (int)(currentLevelTimerMilliseconds / 60000L);
+                int num2 = (int)(currentLevelTimerMilliseconds / 1000L) % 60;
+                int num3 = (int)(currentLevelTimerMilliseconds - (num * 60000) - (num2 * 1000));
+
+                if (num > 99)
+                    timerBuilder.Append((char)((num / 100) + 48));
+
+                timerBuilder.Append((char)((num / 10) + 48));
+                timerBuilder.Append((char)((num % 10) + 48));
+                timerBuilder.Append(':');
+                timerBuilder.Append((char)((num2 / 10) + 48));
+                timerBuilder.Append((char)((num2 % 10) + 48));
+                timerBuilder.Append(':');
+                timerBuilder.Append((char)((num3 / 100) + 48));
+                num3 %= 100;
+                timerBuilder.Append((char)((num3 / 10) + 48));
+                timerBuilder.Append((char)((num3 % 10) + 48));
+
+                return timerBuilder.ToString();
+            }
+            else
+            {
+                // copy of the OG, just don't wanna fetch it via reflection bc that's ugly
+                long currentLevelTimerCentiseconds = Singleton<Game>.Instance.GetCurrentLevelTimerCentiseconds();
+                timerBuilder.Clear();
+
+                int num = (int)(currentLevelTimerCentiseconds / 6000);
+                int num2 = (int)(currentLevelTimerCentiseconds / 100) % 60;
+                int num3 = (int)(currentLevelTimerCentiseconds - num * 6000 - num2 * 100);
+
+                if (num > 99)
+                    timerBuilder.Append((char)(num / 100 + 48));
+
+                timerBuilder.Append((char)(num / 10 + 48));
+                timerBuilder.Append((char)(num % 10 + 48));
+                timerBuilder.Append(':');
+                timerBuilder.Append((char)(num2 / 10 + 48));
+                timerBuilder.Append((char)(num2 % 10 + 48));
+                timerBuilder.Append(':');
+                timerBuilder.Append((char)(num3 / 10 + 48));
+                timerBuilder.Append((char)(num3 % 10 + 48));
+
+                return timerBuilder.ToString();
+            }
         }
     }
 }


### PR DESCRIPTION
Mario's DNFs have been displaying green/red while the displayed timer is the opposite (off by even 20ms at times, he reported). This signified that the actual timer was not accurate to the comparison, so I've made it so the timer that gets displayed is accurate to the internal timer instead of yanking the text from the timer itself. A new function `IGTimer.CreateTimerText()` was created so it can be cleaner.

(The Event Tracker has always been using the internal timer, which is why it has always been a little bit out of sync or too far ahead of the displayed DNF timer (I can't remember which). This is now fixed with this PR.)
![image](https://github.com/MOPSKATER/NeonLite/assets/29069561/8ce129a4-66d1-40b5-867a-8ce6e3f5b275)
![image](https://github.com/MOPSKATER/NeonLite/assets/29069561/aee9371d-c1ea-4c60-b968-4269b236f081)
