### PR TITLE
Fix several community medal issues

### DIFF
--- a/Modules/CommunityMedals.cs
+++ b/Modules/CommunityMedals.cs
@@ -103,11 +103,11 @@ namespace NeonLite.Modules
         {
             if (SceneManager.GetActiveScene().name == "CustomLevel") return;
 
-            if (!_setting_CommunityMedals_enable.Value | _communityMedalTimes == null)
+            if (!_setting_CommunityMedals_enable.Value || _communityMedalTimes == null)
             {
                 //Reset stamp time to red if feature is broken or disables
                 __instance.devTime.color = new Color(0.420f, 0.015f, 0.043f);
-                DestroyNextTime();
+                DestroyNextTime(__instance);
                 return;
             }
 
@@ -138,9 +138,7 @@ namespace NeonLite.Modules
                         nextTime.color = TextColors[nexIndex];
                     }
                     else
-                    {
-                        DestroyNextTime();
-                    }
+                        DestroyNextTime(__instance);
 
                     stamps = __instance.devStamp.GetComponentsInChildren<Image>();
                     if (stamps.Length < 3) return;
@@ -171,6 +169,7 @@ namespace NeonLite.Modules
 
             stamps[1].sprite = DefaultStamp;
             stamps[2].sprite = DefaultStamp;
+            __instance.devTime.color = new Color(0.420f, 0.015f, 0.043f);
 
             if (level.isSidequest && levelStats._timeBestMicroseconds < Utils.ConvertSeconds_FloatToMicroseconds(level.GetTimeDev()))
             {
@@ -247,7 +246,7 @@ namespace NeonLite.Modules
 
         public static TextMeshProUGUI FindOrCreateNextTime(LevelInfo levelInfo)
         {
-            GameObject nextTimeGameObject = GameObject.Find("NextTimeGoalText");
+            GameObject nextTimeGameObject = levelInfo.devTime.transform.parent.Find("NextTimeGoalText")?.gameObject;
             if (nextTimeGameObject == null)
             {
                 nextTimeGameObject =
@@ -262,9 +261,9 @@ namespace NeonLite.Modules
             return nextTimeGameObject.GetComponent<TextMeshProUGUI>();
         }
 
-        public static void DestroyNextTime()
+        public static void DestroyNextTime(LevelInfo levelInfo)
         {
-            GameObject nextTimeGameObject = GameObject.Find("NextTimeGoalText");
+            GameObject nextTimeGameObject = levelInfo.devTime.transform.parent.Find("NextTimeGoalText")?.gameObject;
             if (nextTimeGameObject != null)
             {
                 Object.Destroy(nextTimeGameObject);


### PR DESCRIPTION
This PR fixes the following issues:
- Red times are now set back to their original color instead of keeping what was last set.
- Fix overlapping times issue with sidequests and potentially elsewhere.
